### PR TITLE
security vulnerability

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -205,7 +205,7 @@ tornado=6.0.2=py36h516909a_0
 traitlets=4.3.2=py36_1000
 tzcode=2018g=h14c3975_1001
 udunits2=2.2.27.6=h4e0c4b3_1001
-urllib3=1.24.1=py36_1000
+urllib3>=1.24.2
 wcwidth=0.1.7=py_1
 webencodings=0.5.1=py_1
 wheel=0.33.1=py36_0


### PR DESCRIPTION
Github pointed out that urllib<1.24 is insecure:

Vulnerable versions: < 1.24.2
Patched version: 1.24.2
The urllib3 library before 1.24.2 for Python mishandles certain cases where the desired set of CA certificates is different from the OS store of CA certificates, which results in SSL connections succeeding in situations where a verification failure is the correct outcome. This is related to use of the ssl_context, ca_certs, or ca_certs_dir argument.